### PR TITLE
Fix/fix login modal width inconsistence

### DIFF
--- a/apps/mochi-web/app/layout/navbar.tsx
+++ b/apps/mochi-web/app/layout/navbar.tsx
@@ -47,7 +47,7 @@ export const Navbar = () => {
           ) : (
             <Popover
               trigger={<span className="text-sm font-semibold">Login</span>}
-              panelClassname="px-6 py-4 bg-white-pure border border-gray-200 rounded-xl shadow-md"
+              panelClassname="-translate-x-[8%] sm:-translate-x-[94%]  px-6 py-4 bg-white-pure border border-gray-200 rounded-xl shadow-md"
             >
               <LoginPanel />
             </Popover>

--- a/apps/mochi-web/components/Popover.tsx
+++ b/apps/mochi-web/components/Popover.tsx
@@ -1,7 +1,6 @@
-import { Popover as HeadlessPopover } from '@headlessui/react'
+import { Popover as HeadlessPopover, Transition } from '@headlessui/react'
 import clsx from 'clsx'
-import { Float } from '@headlessui-float/react'
-import { useState } from 'react'
+import { Fragment } from 'react'
 
 type Props = {
   trigger: React.ReactNode
@@ -12,46 +11,46 @@ type Props = {
 }
 
 export const Popover = (props: Props) => {
-  const [isShowing, setIsShowing] = useState(false)
-
   return (
-    <HeadlessPopover
-      onMouseEnter={() => setIsShowing(true)}
-      onMouseLeave={() => setIsShowing(false)}
-      className="flex relative"
-    >
-      <Float
-        show={isShowing}
-        enter="transition ease-out duration-200"
-        enterFrom="opacity-0 translate-y-1"
-        enterTo="opacity-100 translate-y-0"
-        leave="transition ease-in duration-150"
-        leaveFrom="opacity-100 translate-y-0"
-        leaveTo="opacity-0 translate-y-1"
-        placement="bottom-start"
-        flip
-        offset={props.offset ?? 0}
-        strategy="fixed"
-      >
-        <HeadlessPopover.Button
-          className={({ open }) =>
-            clsx(
-              'outline-none h-full flex items-center',
-              props.triggerClassname ?? '',
-              {
-                'text-mochi': open,
-              },
-            )
-          }
-        >
-          {props.trigger}
-        </HeadlessPopover.Button>
-        <HeadlessPopover.Panel
-          className={clsx('mt-3 relative z-50', props.panelClassname)}
-        >
-          {props.children}
-        </HeadlessPopover.Panel>
-      </Float>
+    <HeadlessPopover className="relative">
+      {({ open }) => (
+        <>
+          <HeadlessPopover.Button
+            className={({ open }) =>
+              clsx(
+                'outline-none h-full flex items-center',
+                props.triggerClassname ?? '',
+                {
+                  'text-mochi': open,
+                },
+              )
+            }
+          >
+            {props.trigger}
+          </HeadlessPopover.Button>
+          <Transition
+            show={open}
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+            unmount={false}
+          >
+            <HeadlessPopover.Panel
+              unmount={false}
+              className={clsx(
+                'absolute left-1/2 z-50 mt-3 -translate-x-1/2 transform w-screen max-w-sm',
+                props.panelClassname,
+              )}
+            >
+              {props.children}
+            </HeadlessPopover.Panel>
+          </Transition>
+        </>
+      )}
     </HeadlessPopover>
   )
 }

--- a/apps/mochi-web/components/login.tsx
+++ b/apps/mochi-web/components/login.tsx
@@ -9,6 +9,7 @@ import qs from 'query-string'
 import { useCallback, useEffect, useState } from 'react'
 import { LoginWidget, useMochi } from '@consolelabs/ui-components'
 import { useAuthStore } from '~store'
+import { useRouter } from 'next/router'
 
 const WalletAddIcon = (props: any) => (
   <svg
@@ -60,6 +61,7 @@ export function LoginPanel({ compact = false }: { compact?: boolean }) {
     })
     return data?.url
   })
+  const { push } = useRouter()
 
   const { data: twitterAuthUrl } = useSWR('login-twitter', async () => {
     const data = await API.MOCHI_PROFILE.get(
@@ -185,6 +187,7 @@ export function LoginPanel({ compact = false }: { compact?: boolean }) {
           onOpenChange={setOpen}
           authUrl="https://api-preview.mochi-profile.console.so/api/v1/profiles/auth"
           meUrl="https://api-preview.mochi-profile.console.so/api/v1/profiles/me"
+          onSuccess={() => push('/profile')}
           trigger={
             <button
               type="button"

--- a/apps/mochi-web/components/profile-dropdrown.tsx
+++ b/apps/mochi-web/components/profile-dropdrown.tsx
@@ -25,6 +25,7 @@ export default function ProfileDropdown() {
           />
         </div>
       }
+      panelClassname="-translate-x-[60%]"
     >
       <div className="flex flex-col gap-y-1 py-2 px-2 rounded-xl border border-gray-200 w-[250px] bg-white-pure">
         <Link
@@ -32,7 +33,7 @@ export default function ProfileDropdown() {
           className="flex flex-col py-1 px-3 rounded-md transition hover:bg-gray-100"
         >
           <span className="text-sm text-gray-500">Logged in as</span>
-          <span>{name}</span>
+          <span className="ui-whitespace-nowrap ui-truncate">{name}</span>
         </Link>
         <hr className="my-1 w-full h-px bg-gray-200" />
         <a

--- a/packages/ui/src/login-widget/context.ts
+++ b/packages/ui/src/login-widget/context.ts
@@ -1,0 +1,35 @@
+import { createContext, useContext } from 'react'
+import type { WalletProps } from './wallet'
+
+export enum LoginState {
+  Idle,
+  Connecting,
+  Authenticating,
+  Authenticated,
+  NotInstalled,
+}
+
+interface LoginWidgetContextType {
+  state: LoginState
+  setState: (state: LoginState) => void
+  wallet?: WalletProps
+  setWallet: (wallet?: WalletProps) => void
+  error?: string
+  setError: (error: string) => void
+}
+
+export const LoginWidgetContext = createContext<LoginWidgetContextType | null>(
+  null,
+)
+
+export const useLoginWidgetContext = () => {
+  const loginWidgetContext = useContext(LoginWidgetContext)
+
+  if (!loginWidgetContext) {
+    throw new Error(
+      'useLoginWidgetContext has to be used within <LoginWidgetContext.Provider>',
+    )
+  }
+
+  return loginWidgetContext
+}

--- a/packages/ui/src/login-widget/login-widget.tsx
+++ b/packages/ui/src/login-widget/login-widget.tsx
@@ -10,6 +10,11 @@ import { useMochi } from '../mochi-store'
 import getAvailableWallets from './providers'
 import Wallet from './wallet'
 import type { WalletProps } from './wallet'
+import {
+  LoginState,
+  LoginWidgetContext,
+  useLoginWidgetContext,
+} from './context'
 
 const connectors = getAvailableWallets()
 
@@ -25,6 +30,7 @@ interface WidgetProps {
   onOpenChange: (o: boolean) => void
   trigger?: React.ReactNode
   onSuccess?: OnSuccess
+  onError?: (error: any) => void
   authUrl: string
   meUrl: string
 }
@@ -67,20 +73,13 @@ function Group(props: {
   )
 }
 
-enum LoginState {
-  Idle = 1,
-  Authenticating,
-  NotInstalled,
-}
-
 function Inner({ onSuccess }: { onSuccess: WidgetProps['onSuccess'] }) {
-  const [state, setState] = useState<LoginState>()
-  const [wallet, setWallet] = useState<WalletProps>()
-  const [error, setError] = useState('')
+  const { state, setState, wallet, setWallet, error, setError } =
+    useLoginWidgetContext()
 
   return (
     <>
-      <div className="ui-flex ui-flex-col ui-gap-y-2 ui-p-5 ui-w-full md:ui-overflow-auto md:ui-gap-y-5 md:ui-w-auto md:ui-border-r md:ui-border-neutral-400 md:ui-min-w-[220px]">
+      <div className="ui-flex ui-flex-col ui-gap-y-2 ui-p-5 ui-w-full md:ui-overflow-auto md:ui-gap-y-5 md:ui-w-auto md:ui-border-r md:ui-border-neutral-400 md:ui-min-w-[287px]">
         <Dialog.Title className="ui-text-base">Choose your wallet</Dialog.Title>
         <div className="ui-flex ui-overflow-auto ui-flex-row ui-gap-x-5 md:ui-flex-col md:ui-gap-x-0 md:ui-gap-y-5">
           {Object.entries(connectors).map((e) => {
@@ -90,8 +89,16 @@ function Inner({ onSuccess }: { onSuccess: WidgetProps['onSuccess'] }) {
                 name={e[0]}
                 onError={setError}
                 onSelectWallet={(w) => {
+                  if (
+                    state === LoginState.Connecting ||
+                    state === LoginState.Authenticating ||
+                    (state === LoginState.Authenticated &&
+                      w.name === wallet?.name)
+                  )
+                    return
+
                   setError('')
-                  setState(LoginState.Authenticating)
+                  setState(LoginState.Connecting)
                   setWallet(w)
                 }}
                 onSuccess={onSuccess}
@@ -101,13 +108,15 @@ function Inner({ onSuccess }: { onSuccess: WidgetProps['onSuccess'] }) {
           })}
         </div>
       </div>
-      <div className="ui-flex ui-relative ui-justify-center ui-items-center ui-py-28 ui-px-16 md:ui-py-5 md:ui-px-10 md:ui-min-w-[440px]">
+      <div className="ui-flex ui-relative ui-justify-center ui-items-center ui-py-28 ui-px-16 md:ui-py-5 md:ui-px-10 md:ui-flex-1">
         <Dialog.Close className="ui-hidden ui-absolute ui-top-5 ui-right-5 md:ui-block">
           <IconCrossCircled className="ui-w-6 ui-h-6 ui-transition ui-text-neutral-600 hover:ui-text-neutral-700" />
         </Dialog.Close>
         {(() => {
           switch (true) {
-            case state === LoginState.Authenticating && Boolean(wallet): {
+            case (state === LoginState.Connecting ||
+              state === LoginState.Authenticating) &&
+              Boolean(wallet): {
               const Icon = wallet?.icon ?? IconExclamationTriangle
 
               return (
@@ -122,7 +131,9 @@ function Inner({ onSuccess }: { onSuccess: WidgetProps['onSuccess'] }) {
                     <Icon className="ui-w-12 ui-h-12 ui-rounded" />
                   </div>
                   <span className="ui-mt-4 ui-text-sm">
-                    Opening {wallet?.name}...
+                    {state === LoginState.Connecting
+                      ? `Opening ${wallet?.name}...`
+                      : 'Logging into your account...'}
                   </span>
                   {error ? (
                     <span className="ui-text-sm ui-text-center ui-text-red-500">
@@ -132,6 +143,7 @@ function Inner({ onSuccess }: { onSuccess: WidgetProps['onSuccess'] }) {
                 </div>
               )
             }
+
             case state === LoginState.Idle:
             default:
               return (
@@ -157,14 +169,19 @@ export default function LoginWidget({
   open,
   onOpenChange,
   trigger: _trigger,
-  onSuccess: _onSuccess,
+  onSuccess,
+  onError,
   authUrl,
   meUrl,
 }: WidgetProps) {
   const { user, login, logout } = useMochi()
   const size = useWindowSize()
 
-  const trigger = _trigger ? (
+  const [state, setState] = useState<LoginState>(LoginState.Idle)
+  const [wallet, setWallet] = useState<WalletProps>()
+  const [error, setError] = useState('')
+
+  const trigger = _trigger ?? (
     <button
       className="ui-px-1.5 ui-text-sm ui-rounded-md ui-border ui-shadow ui-bg-neutral-200 ui-border-neutral-500"
       onClick={user ? logout : undefined}
@@ -172,10 +189,11 @@ export default function LoginWidget({
     >
       {user ? 'Logout' : 'Login'}
     </button>
-  ) : null
+  )
 
-  const onSuccess = useCallback<OnSuccess>(
-    (data) => {
+  const handleLogin = useCallback<OnSuccess>(
+    async (data) => {
+      setState(LoginState.Authenticating)
       fetch(`${authUrl}/${data.platform}`, {
         method: 'POST',
         body: JSON.stringify({
@@ -200,14 +218,19 @@ export default function LoginWidget({
                 data.platform === 'ronin'
                   ? data.addresses.map((a) => `ronin:${a.slice(2)}`)
                   : data.addresses,
-              ),
+              ).then(() => {
+                setState(LoginState.Authenticated)
+                onSuccess?.(data)
+              }),
             )
             .catch((e) => {
-              throw e
+              setError(e?.message ?? 'Unknown error')
+              onError?.(e)
             })
         })
         .catch((e) => {
-          throw e
+          setError(e?.message ?? 'Unknown error')
+          onError?.(e)
         })
     },
     [authUrl, login, meUrl],
@@ -215,8 +238,10 @@ export default function LoginWidget({
 
   if (user) return trigger
 
+  let content: React.ReactNode | null = null
+
   if ((size.width ?? 0) <= 768) {
-    return (
+    content = (
       <Drawer.Root>
         {/* @ts-ignore */}
         <Drawer.Trigger asChild>{trigger}</Drawer.Trigger>
@@ -229,7 +254,7 @@ export default function LoginWidget({
             <div className="ui-flex ui-flex-col ui-w-full">
               <div className="ui-sticky ui-top-2 ui-z-10 ui-flex-shrink-0 ui-mx-auto ui-mt-2 ui-w-20 ui-h-1.5 ui-rounded-full ui-bg-neutral-400" />
               <div className="ui-flex ui-flex-col-reverse ui-w-full">
-                <Inner onSuccess={onSuccess} />
+                <Inner onSuccess={handleLogin} />
               </div>
             </div>
           </Drawer.Content>
@@ -238,20 +263,35 @@ export default function LoginWidget({
     )
   }
 
-  return (
+  content = (
     <Dialog.Root onOpenChange={onOpenChange} open={open}>
       <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="ui-fixed ui-z-40 ui-w-screen ui-h-screen ui-bg-black/30" />
         <Dialog.Content asChild>
           <div
-            className="ui-flex ui-fixed ui-top-1/2 ui-left-1/2 ui-z-50 ui-bg-white ui-rounded-2xl -ui-translate-x-1/2 -ui-translate-y-1/2 ui-max-h-[450px]"
+            className="ui-flex ui-fixed ui-top-1/2 ui-w-[720px] ui-left-1/2 ui-z-50 ui-bg-white ui-rounded-2xl -ui-translate-x-1/2 -ui-translate-y-1/2 ui-max-h-[450px]"
             style={{ boxShadow: '0px 0px 20px 0px rgba(0, 0, 0, 0.18)' }}
           >
-            <Inner onSuccess={onSuccess} />
+            <Inner onSuccess={handleLogin} />
           </div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
+  )
+
+  return (
+    <LoginWidgetContext.Provider
+      value={{
+        state,
+        setState,
+        wallet,
+        setWallet,
+        error,
+        setError,
+      }}
+    >
+      {content}
+    </LoginWidgetContext.Provider>
   )
 }

--- a/packages/ui/src/login-widget/login-widget.tsx
+++ b/packages/ui/src/login-widget/login-widget.tsx
@@ -45,7 +45,7 @@ function Group(props: {
   if (!props.wallets.length) return null
   return (
     <div className="ui-flex ui-flex-col md:ui-gap-y-2">
-      <span className="ui-text-xs ui-font-semibold ui-text-neutral-500">
+      <span className="ui-text-xs ui-font-semibold ui-text-neutral-500 ui-uppercase">
         {props.name}
       </span>
       <div className="ui-flex ui-flex-row ui-gap-x-1 md:ui-flex-col md:ui-gap-x-0 md:ui-gap-y-1">
@@ -57,12 +57,12 @@ function Group(props: {
                 props.onSelectWallet(w)
                 return w
                   .connect()
+                  .then(props.onSuccess)
                   .catch((e: { message?: string; cause?: string }) => {
                     props.onError(
                       e.message ?? e.cause ?? 'Something went wrong',
                     )
                   })
-                  .then(props.onSuccess)
               }}
               key={w.name}
             />
@@ -89,14 +89,6 @@ function Inner({ onSuccess }: { onSuccess: WidgetProps['onSuccess'] }) {
                 name={e[0]}
                 onError={setError}
                 onSelectWallet={(w) => {
-                  if (
-                    state === LoginState.Connecting ||
-                    state === LoginState.Authenticating ||
-                    (state === LoginState.Authenticated &&
-                      w.name === wallet?.name)
-                  )
-                    return
-
                   setError('')
                   setState(LoginState.Connecting)
                   setWallet(w)
@@ -233,7 +225,7 @@ export default function LoginWidget({
           onError?.(e)
         })
     },
-    [authUrl, login, meUrl],
+    [authUrl, login, meUrl, onSuccess, onError],
   )
 
   if (user) return trigger

--- a/packages/ui/src/profile-badge/profile-badge.tsx
+++ b/packages/ui/src/profile-badge/profile-badge.tsx
@@ -20,7 +20,9 @@ export default function ProfileBadge({
       type="button"
       {...rest}
     >
-      <Avatar fallback={name} size="sm" smallSrc={platform} src={avatar} />
+      <div className="ui-shrink-0">
+        <Avatar fallback={name} size="sm" smallSrc={platform} src={avatar} />
+      </div>
       <span className="ui-whitespace-nowrap ui-truncate ui-text-sm ui-font-medium ui-text-neutral-800">
         {name}
       </span>


### PR DESCRIPTION
Demo https://www.loom.com/share/205e07377fe94709ad2dcd45207ab619

- [ ] Fix 4 items of login
- [ ] fix https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=c3c54aa7e9004e6799c9bdb1962ae090&pm=s (except "long text — first 4 digits + “…”+ last 3 digits")
- [ ] Fix  https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=30c4e1038da24198ad21d764cec2efa5&pm=s

- Note: component Popover bên mochi web đang dùng headless UI với Float gì đó mà khi nó rê chuột ra ngoài, nó ẩn đi, unmount => tắt luôn modal connect wallet. Đang tạm thời workaround cho nó chạy đc. Sẽ tạo 1 PR khác để implement cái popover bên ui-components