### PR TITLE
fix: sidebar tooltip and expand the invi box

### DIFF
--- a/apps/mochi-web/components/auth-layout.tsx
+++ b/apps/mochi-web/components/auth-layout.tsx
@@ -89,7 +89,7 @@ export default function AuthenticatedLayout({
                     badge: getSidebarBadge['NEW']
                   },
                   {
-                    title: 'Gift your friends',
+                    title: 'Send gifts',
                     Icon: IconSuperGroup,
                     badge: getSidebarBadge['COMING_SOON']
                   },

--- a/packages/ui/src/sidebar/sidebar-item-list.tsx
+++ b/packages/ui/src/sidebar/sidebar-item-list.tsx
@@ -49,8 +49,8 @@ export default function SidebarItemList({
                   />
                 ) : (
                   <Tooltip
-                    arrow="right-center"
-                    className="z-10"
+                    arrow="top-start"
+                    className="z-30"
                     content={item.title}
                     key={item.title}
                   >

--- a/packages/ui/src/sidebar/sidebar.tsx
+++ b/packages/ui/src/sidebar/sidebar.tsx
@@ -64,24 +64,26 @@ export default function Sidebar({
           <SidebarItemList {...{ expanded, isSelected }} items={footerItems} />
           {Boolean(expanded) && (
             <div className="flex px-4 border-t border-neutral-200">
-              <div className="text-xs text-neutral-600 tracking-tight p-2">
+              <div className="p-2 text-xs tracking-tight text-neutral-600">
                 Version 1.0.0
               </div>
             </div>
           )}
         </div>
       </div>
-      <button
-        className="absolute top-4 -right-5 bg-white border border-neutral-200 rounded-r-lg w-5 h-11 justify-center items-center hidden group-hover:flex"
-        onClick={() => setExpanded(!expanded)}
-        type="button"
-      >
-        <IconSidebarArrow
-          className={clsx('text-neutral-800', { 'rotate-180': expanded })}
-          height={25}
-          width={13}
-        />
-      </button>
+      <div className="absolute top-0 hidden w-10 h-full -right-10 group-hover:block">
+        <button
+          className="items-center justify-center w-5 mt-4 bg-white border rounded-r-lg border-neutral-200 h-11"
+          onClick={() => setExpanded(!expanded)}
+          type="button"
+        >
+          <IconSidebarArrow
+            className={clsx('text-neutral-800', { 'rotate-180': expanded })}
+            height={25}
+            width={13}
+          />
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
- [ ] [Sidebar Hover Tooltip](https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=d985923c84dc4ef19def51f4138ad4c8&pm=s)
- [ ] [Sidebar: expand the invi box](https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=b93a44fabc824f8fba753fcff82dc237&pm=s)
- [ ] [Gift your friends —> Send gifts ](https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=b471ee19e1f24d41b46f3b68506da00e&pm=s)

![image](https://github.com/consolelabs/websites/assets/44285614/97ec5c5c-38ea-4314-b2b0-256ab01bdabc)
