### PR TITLE
fix: active state icon color

### DIFF
--- a/packages/theme/src/components/sidebar.ts
+++ b/packages/theme/src/components/sidebar.ts
@@ -69,7 +69,7 @@ const sidebarItemIconClsx = ({
   clsx(
     'min-w-max',
     {
-      'text-blue-500': selected,
+      'text-primary-700': selected,
       'text-neutral-800': !selected && !disabled,
       'text-neutral-600': disabled,
     },

--- a/packages/ui/src/sidebar/sidebar-item.tsx
+++ b/packages/ui/src/sidebar/sidebar-item.tsx
@@ -53,7 +53,7 @@ export default function SidebarItem({
       {Icon !== undefined && (
         <Icon
           className={clsx('min-w-[22px]', {
-            'text-blue-500': selected,
+            'text-primary-700': selected,
             'text-neutral-800': !selected && !disabled,
             'text-neutral-600': disabled,
           })}


### PR DESCRIPTION
**What does this PR do?**

- [ ] Active State icon color

**Related Ticket(s)**

- https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=ad50a5dbd1e548798cbae698f896668c&pm=s

**Media (Loom or gif)**

![image](https://github.com/consolelabs/websites/assets/44285614/6b0c2857-06d4-463d-b8f8-b1df11dbbfae)

