### PR TITLE
fix(input-field): remove extra outline

### DIFF
--- a/.changeset/hungry-stingrays-behave.md
+++ b/.changeset/hungry-stingrays-behave.md
@@ -1,0 +1,7 @@
+---
+'@consolelabs/theme': patch
+'@consolelabs/input-field': patch
+'@consolelabs/core': patch
+---
+
+Remove extra outline input field

--- a/packages/theme/src/components/input-field.ts
+++ b/packages/theme/src/components/input-field.ts
@@ -31,7 +31,7 @@ const inputWrapperVariants = cva(
 
 const inputFieldVariants = cva(
   [
-    'flex-1 border-none outline-0 text-neutral-800 placeholder:text-neutral-500 disabled:bg-transparent disabled:text-neutral-500',
+    'flex-1 border-none outline-none text-neutral-800 placeholder:text-neutral-500 disabled:bg-transparent disabled:text-neutral-500',
   ],
   {
     variants: {


### PR DESCRIPTION
Remove extra outline in input field:

<img width="1200" alt="image" src="https://github.com/consolelabs/websites/assets/12707960/b4ae9fc9-8b26-4be4-8aa1-c8fb639482ef">
